### PR TITLE
Pass string from plugin to JS

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,18 @@
     };
 
     WebAssembly.instantiateStreaming(fetch("bin/universal_elevators_plugin_bg.wasm"), importObject).then(
-        (obj) => console.log(obj.instance.exports.add(1, 2))
+        (obj) => {
+            let mem = obj.instance.exports.memory
+            const strPtr = obj.instance.exports.get_game_name()
+            const strLen = obj.instance.exports.get_game_name_len()
+            const arrayBuffer = mem.buffer
+            const buffer = new Uint8Array(arrayBuffer)
+            let myStr = "";
+            for (let i = strPtr; i < strPtr + strLen; ++i) {
+                myStr += String.fromCharCode(buffer[i])
+            }
+            console.log(myStr)
+        }
     );
 </script>
 </html>


### PR DESCRIPTION
In this PR, I implement minimally-viable functionality for reading a string from the Universal Elevators WASM module memory.  This will be generalized and used to pass the game state from the WASM module into JS for display in the DOM.